### PR TITLE
Update TapkeyMobileLib.podspec

### DIFF
--- a/TapkeyMobileLib/2.30.0.0/TapkeyMobileLib.podspec
+++ b/TapkeyMobileLib/2.30.0.0/TapkeyMobileLib.podspec
@@ -20,7 +20,7 @@
             :ios => "11.0",
             :watchos => "6.2"
         }
-        cs.ios.dependency 'SocketRocket', '0.5.1'
+        cs.ios.dependency 'SocketRocket', '0.6.0'
         cs.dependency 'JRE-Slim', '2.8.1.3-tk'
         cs.dependency 'GsonJ2ObjC-Light', '2.8.6.4'
 


### PR DESCRIPTION
For react native users solves
```
[!] CocoaPods could not find compatible versions for pod "SocketRocket":
  In Podfile:
    FlipperKit/FlipperKitUserDefaultsPlugin (~> 0.174.0) was resolved to 0.174.0, which depends on
      FlipperKit/Core (= 0.174.0) was resolved to 0.174.0, which depends on
        SocketRocket (~> 0.6.0)

    TapkeyMobileLib (= 2.30.0.0) was resolved to 2.30.0.0, which depends on
      TapkeyMobileLib/Core (= 2.30.0.0) was resolved to 2.30.0.0, which depends on
        SocketRocket (= 0.5.1)
```